### PR TITLE
Handle missing professor ratings gracefully

### DIFF
--- a/theovalguide-front/app/professors/[slug]/components/OverallScore.tsx
+++ b/theovalguide-front/app/professors/[slug]/components/OverallScore.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { fmt1, isFiniteNumber } from "@/app/classes/[code]/components/ui-helpers";
+
 import StarRow from "./StarRow";
 
 export default function OverallScore({
@@ -13,10 +15,21 @@ export default function OverallScore({
   uni: string;
   overall: number | null;
 }) {
+  const displayScore = fmt1(overall);
+  const hasRating = isFiniteNumber(overall);
+  const badgeLabel = hasRating
+    ? `Overall rating ${displayScore} out of 5`
+    : "Overall rating not available";
+
   return (
     <div className="border-border bg-card flex items-center gap-5 rounded-2xl border p-6 shadow-sm">
-      <div className="bg-brand grid h-16 w-16 place-items-center rounded-xl text-[var(--brand-contrast)]">
-        <span className="text-xl font-bold">{overall?.toFixed(1)}</span>
+      <div
+        className="bg-brand grid h-16 w-16 place-items-center rounded-xl text-[var(--brand-contrast)]"
+        aria-label={badgeLabel}
+      >
+        <span className="text-xl font-bold" aria-hidden="true">
+          {displayScore}
+        </span>
       </div>
       <div className="min-w-0">
         <h1 className="truncate text-xl font-semibold md:text-2xl">{name}</h1>
@@ -24,7 +37,7 @@ export default function OverallScore({
           {dept} • {uni}
         </p>
         <div className="mt-1">
-          <StarRow rating={overall ?? 0} />
+          <StarRow rating={overall} />
         </div>
       </div>
     </div>

--- a/theovalguide-front/app/professors/[slug]/components/StarRow.tsx
+++ b/theovalguide-front/app/professors/[slug]/components/StarRow.tsx
@@ -1,17 +1,24 @@
 "use client";
 
-export default function StarRow({ rating }: { rating: number }) {
-  const full = Math.floor(rating);
-  const half = rating - full >= 0.5;
+import { fmt1, isFiniteNumber } from "@/app/classes/[code]/components/ui-helpers";
+
+export default function StarRow({ rating }: { rating: number | null | undefined }) {
+  const hasRating = isFiniteNumber(rating);
+  const value = hasRating ? rating : 0;
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  const aria = hasRating ? `${fmt1(value)} out of 5` : "Not rated yet";
+  const starColor = hasRating ? "text-brand" : "text-muted-foreground/60";
+
   return (
-    <div className="inline-flex items-center gap-1" aria-label={`${rating} out of 5`}>
+    <div className="inline-flex items-center gap-1" aria-label={aria}>
       {Array.from({ length: 5 }).map((_, i) => {
         const isFull = i < full;
         const isHalf = !isFull && i === full && half;
         return (
           <svg
             key={i}
-            className="text-brand h-4 w-4"
+            className={`${starColor} h-4 w-4`}
             viewBox="0 0 24 24"
             fill={isFull ? "currentColor" : "none"}
             stroke="currentColor"


### PR DESCRIPTION
## Summary
- format the professor header rating with the shared `fmt1` helper so missing values render as a placeholder
- add accessible labels to the overall score badge and make the professor star row handle absent ratings
- dim the professor star icons when no rating is available to keep the header display consistent

## Testing
- pnpm lint *(emits existing warning about `SearchItemSchema` in `app/search/results-client.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b94aea148332811001da85389c26