### PR TITLE
Fix forgot password email schema

### DIFF
--- a/theovalguide-front/components/forms/forget-password-form.tsx
+++ b/theovalguide-front/components/forms/forget-password-form.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 
 // Schema
 const forgotSchema = z.object({
-  email: z.email("Enter a valid email address"),
+  email: z.string().email("Enter a valid email address"),
 });
 type ForgotValues = z.infer<typeof forgotSchema>;
 


### PR DESCRIPTION
## Summary
- replace the nonexistent `z.email` call with `z.string().email` in the forgot password form schema

## Testing
- pnpm --dir theovalguide-front lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d7352fa483329e613370a66ca761