### PR TITLE
Fix schema validation logging for class page

### DIFF
--- a/theovalguide-front/app/classes/[code]/page.tsx
+++ b/theovalguide-front/app/classes/[code]/page.tsx
@@ -102,7 +102,7 @@ export default async function Page({ params }: Params) {
   const json = await res.json();
   const parsed = ClassResultSchema.safeParse(json);
   if (!parsed.success) {
-    console.error(z.treeifyError(parsed.error));
+    console.error(parsed.error.format());
     return (
       <div className="bg-background text-foreground min-h-[100svh]">
         <main className="container-responsive py-10">


### PR DESCRIPTION
## Summary
- log schema validation failures on the class page with Zod's supported error formatting API
- keep returning the existing fallback UI when parsing fails

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d73548008332bb6069de5c76575f