### PR TITLE
Allow null difficulty values in class search results

### DIFF
--- a/theovalguide-front/app/professors/[slug]/components/ProfessorReviewForm.tsx
+++ b/theovalguide-front/app/professors/[slug]/components/ProfessorReviewForm.tsx
@@ -18,7 +18,7 @@ const SearchClassHit = z.object({
   id: z.string(), // code, e.g. "CS 2201"
   title: z.string(), // "CS 2201 — Data Structures"
   subtitle: z.string(), // "Computer Science — Ohio State University"
-  difficulty: z.number().optional(),
+  difficulty: z.number().nullish(),
 });
 type SearchClassHit = z.infer<typeof SearchClassHit>;
 


### PR DESCRIPTION
## Summary
- allow class search hits in the professor review form to accept null difficulty values

## Testing
- pnpm lint
- pnpm dev (smoke test; started server and confirmed it booted)


------
https://chatgpt.com/codex/tasks/task_e_68c9d7365dc08332ba0922e593469a01