### PR TITLE
Fix sign-in redirect to home page

### DIFF
--- a/theovalguide-front/components/forms/sign-in.tsx
+++ b/theovalguide-front/components/forms/sign-in.tsx
@@ -91,7 +91,7 @@ export function SignInForm({ className, ...props }: React.ComponentPropsWithoutR
         res.status < 300 &&
         (maybeOk.success ? (maybeOk.data.ok ?? true) : true)
       ) {
-        router.push("/dashboard");
+        router.push("/");
         return;
       }
       throw new Error("Unexpected login response");


### PR DESCRIPTION
## Summary
- update the post-login redirect to send users to the home page so it targets an existing route

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d73a768c83328ee0a6d7f045fe06