### PR TITLE
Add summary endpoints and improve refresh handling

### DIFF
--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/SummaryResponse.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/SummaryResponse.java
@@ -1,0 +1,4 @@
+package com.ross.theovalguide.DTOS;
+
+public record SummaryResponse(String summary) {
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/ClassController.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/ClassController.java
@@ -1,11 +1,14 @@
 package com.ross.theovalguide.controllers;
 
 import com.ross.theovalguide.DTOS.ClassResponse;
+import com.ross.theovalguide.DTOS.SummaryResponse;
 import com.ross.theovalguide.service.ClassQueryService;
+import com.ross.theovalguide.service.SummaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,10 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ClassController {
     private final ClassQueryService service;
+    private final SummaryService summaryService;
 
     /// GET /api/classes/{code}
     @GetMapping("/classes/{code}")
     public ResponseEntity<ClassResponse> getOneByCode(@PathVariable String code) {
         return ResponseEntity.ok(service.getClassByCode(code));
+    }
+
+    /// POST /api/classes/{code}/summary
+    @PostMapping("/classes/{code}/summary")
+    public ResponseEntity<SummaryResponse> summarizeClass(@PathVariable String code) {
+        return ResponseEntity.ok(summaryService.summarizeClass(code));
     }
 }

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/ProfessorController.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/ProfessorController.java
@@ -1,11 +1,14 @@
 package com.ross.theovalguide.controllers;
 
 import com.ross.theovalguide.DTOS.ProfessorResponse;
+import com.ross.theovalguide.DTOS.SummaryResponse;
 import com.ross.theovalguide.service.ProfessorQueryService;
+import com.ross.theovalguide.service.SummaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,10 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProfessorController {
     private final ProfessorQueryService service;
+    private final SummaryService summaryService;
 
     /// GET /api/professors/{slug}
     @GetMapping("/professors/{slug}")
     public ResponseEntity<ProfessorResponse> getOneBySlug(@PathVariable String slug) {
         return ResponseEntity.ok(service.getProfessorBySlug(slug));
+    }
+
+    /// POST /api/professors/{slug}/summary
+    @PostMapping("/professors/{slug}/summary")
+    public ResponseEntity<SummaryResponse> summarizeProfessor(@PathVariable String slug) {
+        return ResponseEntity.ok(summaryService.summarizeProfessor(slug));
     }
 }

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/service/SummaryService.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/service/SummaryService.java
@@ -1,0 +1,261 @@
+package com.ross.theovalguide.service;
+
+import com.ross.theovalguide.DTOS.ClassProfessorBriefDto;
+import com.ross.theovalguide.DTOS.ClassResponse;
+import com.ross.theovalguide.DTOS.LabelCountDto;
+import com.ross.theovalguide.DTOS.ProfessorResponse;
+import com.ross.theovalguide.DTOS.ReviewItemDto;
+import com.ross.theovalguide.DTOS.SummaryResponse;
+import com.ross.theovalguide.DTOS.TagDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SummaryService {
+
+    private final ClassQueryService classQueryService;
+    private final ProfessorQueryService professorQueryService;
+
+    @Transactional(readOnly = true)
+    public SummaryResponse summarizeClass(String code) {
+        ClassResponse data = classQueryService.getClassByCode(code);
+        String summary = buildClassSummary(data);
+        return new SummaryResponse(summary);
+    }
+
+    @Transactional(readOnly = true)
+    public SummaryResponse summarizeProfessor(String slug) {
+        ProfessorResponse data = professorQueryService.getProfessorBySlug(slug);
+        String summary = buildProfessorSummary(data);
+        return new SummaryResponse(summary);
+    }
+
+    private String buildClassSummary(ClassResponse data) {
+        List<String> sentences = new ArrayList<>();
+
+        String code = safe(data.code());
+        String title = safe(data.title());
+        String department = safe(data.department());
+        String university = safe(data.university());
+
+        StringBuilder intro = new StringBuilder();
+        if (!code.isEmpty()) {
+            intro.append(code);
+        }
+        if (!title.isEmpty()) {
+            if (intro.length() > 0) {
+                intro.append(" — ");
+            }
+            intro.append(title);
+        }
+        if (intro.length() == 0) {
+            intro.append("This course");
+        }
+        intro.append(" is offered by the ");
+        intro.append(!department.isEmpty() ? department : "department");
+        intro.append(" department at ");
+        intro.append(!university.isEmpty() ? university : "the university");
+        intro.append(".");
+        sentences.add(intro.toString());
+
+        int totalRatings = data.totalRatings();
+        BigDecimal difficulty = data.difficulty();
+        if (totalRatings > 0) {
+            if (difficulty != null) {
+                sentences.add(String.format(Locale.US,
+                        "Students report an average difficulty of %s/5 based on %d rating%s.",
+                        formatOneDecimal(difficulty),
+                        totalRatings,
+                        plural(totalRatings)));
+            } else {
+                sentences.add(String.format(Locale.US,
+                        "Students have submitted %d difficulty rating%s so far.",
+                        totalRatings,
+                        plural(totalRatings)));
+            }
+        } else {
+            sentences.add("We have not collected enough difficulty ratings yet.");
+        }
+
+        Optional<LabelCountDto> commonDifficulty = data.difficultyBuckets().stream()
+                .filter(b -> b.count() > 0)
+                .max(Comparator.comparingLong(LabelCountDto::count));
+        commonDifficulty.ifPresent(bucket -> sentences.add(String.format(Locale.US,
+                "The most common response marks the course as a %s on the difficulty scale.",
+                bucket.label())));
+
+        List<String> tagLabels = data.tags().stream()
+                .map(TagDto::label)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .limit(3)
+                .collect(Collectors.toList());
+        if (!tagLabels.isEmpty()) {
+            sentences.add("Popular tags include " + joinList(tagLabels) + ".");
+        }
+
+        List<String> professorNames = data.professors().stream()
+                .map(ClassProfessorBriefDto::name)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .limit(3)
+                .collect(Collectors.toList());
+        if (!professorNames.isEmpty()) {
+            sentences.add("Recent instructors include " + joinList(professorNames) + ".");
+        }
+
+        int adviceCount = data.advices() == null ? 0 : data.advices().size();
+        if (adviceCount > 0) {
+            sentences.add(String.format(Locale.US,
+                    "Students have shared %d piece%s of advice for this class.",
+                    adviceCount,
+                    plural(adviceCount)));
+        }
+
+        String summary = joinSentences(sentences);
+        return summary.isBlank() ? "We’ll add a summary once we have more feedback." : summary;
+    }
+
+    private String buildProfessorSummary(ProfessorResponse data) {
+        List<String> sentences = new ArrayList<>();
+
+        String name = safe(data.name());
+        String department = safe(data.department());
+        String university = safe(data.university());
+
+        StringBuilder intro = new StringBuilder();
+        if (!name.isEmpty()) {
+            intro.append(name);
+        } else {
+            intro.append("This professor");
+        }
+        if (!department.isEmpty() || !university.isEmpty()) {
+            intro.append(" teaches");
+            if (!department.isEmpty()) {
+                intro.append(" in the ").append(department).append(" department");
+            }
+            if (!university.isEmpty()) {
+                if (!department.isEmpty()) {
+                    intro.append(" at ");
+                } else {
+                    intro.append(" at ");
+                }
+                intro.append(university);
+            }
+        } else {
+            intro.append(" teaches at our university");
+        }
+        intro.append(".");
+        sentences.add(intro.toString());
+
+        int totalRatings = data.totalRatings();
+        BigDecimal overall = data.overall();
+        if (totalRatings > 0 && overall != null) {
+            sentences.add(String.format(Locale.US,
+                    "Students have submitted %d rating%s with an average score of %s/5.",
+                    totalRatings,
+                    plural(totalRatings),
+                    formatOneDecimal(overall)));
+        } else if (totalRatings > 0) {
+            sentences.add(String.format(Locale.US,
+                    "Students have submitted %d rating%s so far.",
+                    totalRatings,
+                    plural(totalRatings)));
+        } else {
+            sentences.add("We have not collected enough ratings yet to calculate an average score.");
+        }
+
+        Optional<LabelCountDto> commonRating = data.buckets().stream()
+                .filter(b -> b.count() > 0)
+                .max(Comparator.comparingLong(LabelCountDto::count));
+        commonRating.ifPresent(bucket -> sentences.add(String.format(Locale.US,
+                "Most reviews award a %s out of 5.",
+                bucket.label())));
+
+        List<String> tagLabels = data.tags().stream()
+                .map(TagDto::label)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .limit(3)
+                .collect(Collectors.toList());
+        if (!tagLabels.isEmpty()) {
+            sentences.add("Common feedback highlights " + joinList(tagLabels) + ".");
+        }
+
+        List<ReviewItemDto> reviews = data.reviews();
+        int reviewCount = reviews == null ? 0 : reviews.size();
+        if (reviewCount > 0) {
+            Map<String, Long> courseFrequency = reviews.stream()
+                    .map(ReviewItemDto::course)
+                    .filter(Objects::nonNull)
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.groupingBy(s -> s, Collectors.counting()));
+            String topCourse = courseFrequency.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse(null);
+
+            StringBuilder reviewSentence = new StringBuilder();
+            reviewSentence.append(String.format(Locale.US,
+                    "We have %d recent review%s on file",
+                    reviewCount,
+                    plural(reviewCount)));
+            if (topCourse != null) {
+                reviewSentence.append(", with many referencing ").append(topCourse);
+            }
+            reviewSentence.append(".");
+            sentences.add(reviewSentence.toString());
+        }
+
+        String summary = joinSentences(sentences);
+        return summary.isBlank() ? "We’ll add a summary once we have more feedback." : summary;
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private String formatOneDecimal(BigDecimal value) {
+        if (value == null) return "";
+        DecimalFormat df = new DecimalFormat("0.0");
+        df.setRoundingMode(RoundingMode.HALF_UP);
+        return df.format(value);
+    }
+
+    private String joinList(List<String> values) {
+        if (values.isEmpty()) return "";
+        if (values.size() == 1) return values.get(0);
+        if (values.size() == 2) return values.get(0) + " and " + values.get(1);
+        String allButLast = String.join(", ", values.subList(0, values.size() - 1));
+        return allButLast + ", and " + values.get(values.size() - 1);
+    }
+
+    private String joinSentences(List<String> sentences) {
+        return sentences.stream()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(" "));
+    }
+
+    private String plural(long count) {
+        return count == 1 ? "" : "s";
+    }
+}

--- a/theovalguide-front/app/classes/[code]/components/SummaryCard.tsx
+++ b/theovalguide-front/app/classes/[code]/components/SummaryCard.tsx
@@ -1,19 +1,41 @@
 "use client";
 
-export default function SummaryCard({ text, onRefresh }: { text: string; onRefresh?: () => void }) {
+type SummaryCardProps = {
+  text: string;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+  error?: string | null;
+};
+
+export default function SummaryCard({
+  text,
+  onRefresh,
+  isRefreshing = false,
+  error,
+}: SummaryCardProps) {
   return (
     <div className="border-border bg-card rounded-2xl border p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-semibold">AI Summary of This Course</h3>
-        <button
-          type="button"
-          onClick={onRefresh}
-          className="border-border bg-card hover:bg-muted/70 ring-brand rounded-md border px-3 py-1.5 text-xs focus:ring-2 focus:outline-none"
-        >
-          Refresh
-        </button>
+        {onRefresh ? (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            className="border-border bg-card hover:bg-muted/70 ring-brand rounded-md border px-3 py-1.5 text-xs focus:ring-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isRefreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        ) : null}
       </div>
-      <p className="text-foreground mt-3 text-sm leading-6">{text}</p>
+      <p className="text-foreground mt-3 text-sm leading-6" aria-live="polite">
+        {text}
+      </p>
+      {error ? (
+        <p className="mt-2 text-xs text-red-500" role="alert">
+          {error}
+        </p>
+      ) : null}
       <p className="text-muted-foreground mt-2 text-xs">
         Summary is generated from student reviews and may contain inaccuracies.
       </p>

--- a/theovalguide-front/app/professors/[slug]/components/SummaryCard.tsx
+++ b/theovalguide-front/app/professors/[slug]/components/SummaryCard.tsx
@@ -1,19 +1,41 @@
 "use client";
 
-export default function SummaryCard({ text, onRefresh }: { text: string; onRefresh?: () => void }) {
+type SummaryCardProps = {
+  text: string;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+  error?: string | null;
+};
+
+export default function SummaryCard({
+  text,
+  onRefresh,
+  isRefreshing = false,
+  error,
+}: SummaryCardProps) {
   return (
     <div className="border-border bg-card rounded-2xl border p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-semibold">AI Summary of Student Feedback</h3>
-        <button
-          type="button"
-          onClick={onRefresh}
-          className="border-border bg-card hover:bg-muted/70 ring-brand rounded-md border px-3 py-1.5 text-xs focus:ring-2 focus:outline-none"
-        >
-          Refresh
-        </button>
+        {onRefresh ? (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            className="border-border bg-card hover:bg-muted/70 ring-brand rounded-md border px-3 py-1.5 text-xs focus:ring-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isRefreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        ) : null}
       </div>
-      <p className="text-foreground mt-3 text-sm leading-6">{text}</p>
+      <p className="text-foreground mt-3 text-sm leading-6" aria-live="polite">
+        {text}
+      </p>
+      {error ? (
+        <p className="mt-2 text-xs text-red-500" role="alert">
+          {error}
+        </p>
+      ) : null}
       <p className="text-muted-foreground mt-2 text-xs">
         This summary is generated from student reviews and may contain inaccuracies.
       </p>


### PR DESCRIPTION
## Summary
- add a SummaryService and DTO to generate textual summaries for classes and professors
- expose POST /api/classes/{code}/summary and /api/professors/{slug}/summary endpoints that return the generated text
- update summary cards and results clients to show loading/error states and handle failed refresh requests gracefully

## Testing
- pnpm lint
- ./mvnw test *(fails: Maven wrapper cannot download Maven binaries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d745f24c833284399b6bc9dab435