### PR TITLE
Add authentication controller and password reset flows

### DIFF
--- a/TheOvalGuide-back/pom.xml
+++ b/TheOvalGuide-back/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
@@ -67,6 +71,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/BasicResponse.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/BasicResponse.java
@@ -1,0 +1,5 @@
+package com.ross.theovalguide.DTOS.auth;
+
+public record BasicResponse(boolean ok) {
+    public static final BasicResponse OK = new BasicResponse(true);
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/ForgotPasswordRequest.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/ForgotPasswordRequest.java
@@ -1,0 +1,13 @@
+package com.ross.theovalguide.DTOS.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ForgotPasswordRequest(
+        @NotBlank
+        @Email
+        @Size(max = 255)
+        String email
+) {
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/LoginRequest.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.ross.theovalguide.DTOS.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+        @NotBlank
+        @Size(max = 255)
+        String login,
+        @NotBlank
+        @Size(min = 1, max = 255)
+        String password
+) {
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/RegisterRequest.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/RegisterRequest.java
@@ -1,0 +1,26 @@
+package com.ross.theovalguide.DTOS.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank
+        @Size(min = 3, max = 32)
+        @Pattern(regexp = "^[a-zA-Z0-9._-]+$", message = "Username may only contain letters, numbers, dots, underscores, and hyphens")
+        String username,
+        @NotBlank
+        @Email
+        @Size(max = 255)
+        String email,
+        @NotBlank
+        @Email
+        @Size(max = 255)
+        @Pattern(regexp = ".*\\.edu$", message = "School email must end with .edu")
+        String schoolEmail,
+        @NotBlank
+        @Size(min = 8, max = 255)
+        String password
+) {
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/UpdatePasswordRequest.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/DTOS/auth/UpdatePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.ross.theovalguide.DTOS.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePasswordRequest(
+        @NotBlank
+        @Size(min = 8, max = 255)
+        String password,
+        @NotBlank
+        String token
+) {
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/config/AuthConfig.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package com.ross.theovalguide.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/config/WebConfig.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/config/WebConfig.java
@@ -8,7 +8,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
+        configureMapping(registry.addMapping("/api/**"));
+        configureMapping(registry.addMapping("/auth/**"));
+    }
+
+    private void configureMapping(CorsRegistry.CorsRegistration registration) {
+        registration
                 .allowedOrigins(
                         "http://localhost:3000",
                         "http://localhost:5173"

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/AuthController.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/controllers/AuthController.java
@@ -1,0 +1,78 @@
+package com.ross.theovalguide.controllers;
+
+import com.ross.theovalguide.DTOS.auth.BasicResponse;
+import com.ross.theovalguide.DTOS.auth.ForgotPasswordRequest;
+import com.ross.theovalguide.DTOS.auth.LoginRequest;
+import com.ross.theovalguide.DTOS.auth.RegisterRequest;
+import com.ross.theovalguide.DTOS.auth.UpdatePasswordRequest;
+import com.ross.theovalguide.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    static final String AUTH_COOKIE_NAME = "oval_session";
+    private static final boolean COOKIE_SECURE = false;
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<BasicResponse> login(@Valid @RequestBody LoginRequest request) {
+        var result = authService.login(request.login(), request.password());
+
+        ResponseCookie cookie = buildAuthCookie(result.token(), result.ttl());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(BasicResponse.OK);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<BasicResponse> register(@Valid @RequestBody RegisterRequest request) {
+        authService.register(request.username(), request.email(), request.password());
+        return ResponseEntity.status(HttpStatus.CREATED).body(BasicResponse.OK);
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<BasicResponse> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        authService.initiatePasswordReset(request.email());
+        return ResponseEntity.ok(BasicResponse.OK);
+    }
+
+    @PostMapping("/update-password")
+    public ResponseEntity<BasicResponse> updatePassword(@Valid @RequestBody UpdatePasswordRequest request) {
+        authService.updatePassword(request.token(), request.password());
+        return ResponseEntity.ok(BasicResponse.OK);
+    }
+
+    @ExceptionHandler(AuthService.AuthException.class)
+    public ResponseEntity<Map<String, String>> handleAuthException(AuthService.AuthException exception) {
+        String message = exception.getMessage() == null ? "Request failed" : exception.getMessage();
+        return ResponseEntity.status(exception.getStatus())
+                .body(Map.of("message", message));
+    }
+
+    private ResponseCookie buildAuthCookie(String token, Duration ttl) {
+        return ResponseCookie.from(AUTH_COOKIE_NAME, token)
+                .httpOnly(true)
+                .secure(COOKIE_SECURE)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(ttl)
+                .build();
+    }
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/model/PasswordResetToken.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/model/PasswordResetToken.java
@@ -1,0 +1,37 @@
+package com.ross.theovalguide.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken extends BaseEntity {
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "uuid")
+    private UserAccount user;
+
+    @Column(name = "token_hash", columnDefinition = "text", nullable = false, unique = true)
+    private String tokenHash;
+
+    @Column(name = "expires_at", columnDefinition = "timestamptz", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used = false;
+
+    @Column(name = "used_at", columnDefinition = "timestamptz")
+    private Instant usedAt;
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/model/SessionToken.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/model/SessionToken.java
@@ -1,0 +1,31 @@
+package com.ross.theovalguide.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "session_tokens")
+public class SessionToken extends BaseEntity {
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "uuid")
+    private UserAccount user;
+
+    @Column(name = "token_hash", columnDefinition = "text", nullable = false, unique = true)
+    private String tokenHash;
+
+    @Column(name = "expires_at", columnDefinition = "timestamptz", nullable = false)
+    private Instant expiresAt;
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/PasswordResetTokenRepository.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/PasswordResetTokenRepository.java
@@ -1,0 +1,17 @@
+package com.ross.theovalguide.repo;
+
+import com.ross.theovalguide.model.PasswordResetToken;
+import com.ross.theovalguide.model.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, UUID> {
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+
+    long deleteByUser(UserAccount user);
+
+    List<PasswordResetToken> findAllByUser(UserAccount user);
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/SessionTokenRepository.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/SessionTokenRepository.java
@@ -1,0 +1,17 @@
+package com.ross.theovalguide.repo;
+
+import com.ross.theovalguide.model.SessionToken;
+import com.ross.theovalguide.model.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SessionTokenRepository extends JpaRepository<SessionToken, UUID> {
+    Optional<SessionToken> findByTokenHash(String tokenHash);
+
+    long deleteByUser(UserAccount user);
+
+    List<SessionToken> findAllByUser(UserAccount user);
+}

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/UserRepository.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/repo/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<UserAccount, UUID> {
     Optional<UserAccount> findByUsernameIgnoreCase(String username);
+
+    Optional<UserAccount> findByEmailIgnoreCase(String email);
 }

--- a/TheOvalGuide-back/src/main/java/com/ross/theovalguide/service/AuthService.java
+++ b/TheOvalGuide-back/src/main/java/com/ross/theovalguide/service/AuthService.java
@@ -1,0 +1,192 @@
+package com.ross.theovalguide.service;
+
+import com.ross.theovalguide.model.PasswordResetToken;
+import com.ross.theovalguide.model.SessionToken;
+import com.ross.theovalguide.model.UserAccount;
+import com.ross.theovalguide.repo.PasswordResetTokenRepository;
+import com.ross.theovalguide.repo.SessionTokenRepository;
+import com.ross.theovalguide.repo.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private static final Duration SESSION_DURATION = Duration.ofDays(30);
+    private static final Duration PASSWORD_RESET_DURATION = Duration.ofHours(2);
+
+    private final UserRepository userRepository;
+    private final SessionTokenRepository sessionTokenRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Transactional
+    public LoginSuccess login(String login, String password) {
+        String lookup = login == null ? "" : login.trim();
+        if (lookup.isEmpty()) {
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Invalid email/username or password");
+        }
+
+        UserAccount user = findByLogin(lookup)
+                .orElseThrow(() -> new AuthException(HttpStatus.UNAUTHORIZED, "Invalid email/username or password"));
+
+        if (!passwordEncoder.matches(password, user.getPasswordHash())) {
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Invalid email/username or password");
+        }
+
+        sessionTokenRepository.deleteByUser(user);
+
+        String rawToken = generateToken();
+        String tokenHash = hashToken(rawToken);
+
+        SessionToken sessionToken = new SessionToken();
+        sessionToken.setUser(user);
+        sessionToken.setTokenHash(tokenHash);
+        sessionToken.setExpiresAt(Instant.now().plus(SESSION_DURATION));
+        sessionTokenRepository.save(sessionToken);
+
+        return new LoginSuccess(rawToken, SESSION_DURATION);
+    }
+
+    @Transactional
+    public UserAccount register(String username, String email, String rawPassword) {
+        String normalizedUsername = username == null ? "" : username.trim();
+        String normalizedEmail = email == null ? "" : email.trim();
+        if (!normalizedEmail.isEmpty()) {
+            normalizedEmail = normalizedEmail.toLowerCase(Locale.ROOT);
+        }
+
+        if (normalizedUsername.isEmpty()) {
+            throw new AuthException(HttpStatus.BAD_REQUEST, "Username is required");
+        }
+        if (normalizedEmail.isEmpty()) {
+            throw new AuthException(HttpStatus.BAD_REQUEST, "Email is required");
+        }
+
+        if (userRepository.findByUsernameIgnoreCase(normalizedUsername).isPresent()) {
+            throw new AuthException(HttpStatus.CONFLICT, "Username already in use");
+        }
+        if (userRepository.findByEmailIgnoreCase(normalizedEmail).isPresent()) {
+            throw new AuthException(HttpStatus.CONFLICT, "Email already in use");
+        }
+
+        UserAccount account = new UserAccount();
+        account.setUsername(normalizedUsername);
+        account.setEmail(normalizedEmail);
+        account.setPasswordHash(passwordEncoder.encode(rawPassword));
+
+        return userRepository.save(account);
+    }
+
+    @Transactional
+    public Optional<String> initiatePasswordReset(String email) {
+        String normalizedEmail = email == null ? "" : email.trim();
+        if (!normalizedEmail.isEmpty()) {
+            normalizedEmail = normalizedEmail.toLowerCase(Locale.ROOT);
+        }
+        if (normalizedEmail.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return userRepository.findByEmailIgnoreCase(normalizedEmail)
+                .map(this::createResetTokenForUser);
+    }
+
+    @Transactional
+    public void updatePassword(String rawToken, String newPassword) {
+        if (rawToken == null || rawToken.isBlank()) {
+            throw new AuthException(HttpStatus.BAD_REQUEST, "Reset token is required");
+        }
+
+        String tokenHash = hashToken(rawToken);
+        PasswordResetToken token = passwordResetTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new AuthException(HttpStatus.BAD_REQUEST, "Reset link is invalid or expired"));
+
+        if (token.isUsed() || token.getExpiresAt().isBefore(Instant.now())) {
+            throw new AuthException(HttpStatus.BAD_REQUEST, "Reset link is invalid or expired");
+        }
+
+        UserAccount user = token.getUser();
+        user.setPasswordHash(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        sessionTokenRepository.deleteByUser(user);
+
+        token.setUsed(true);
+        token.setUsedAt(Instant.now());
+        passwordResetTokenRepository.save(token);
+    }
+
+    private Optional<UserAccount> findByLogin(String login) {
+        Optional<UserAccount> byUsername = userRepository.findByUsernameIgnoreCase(login);
+        if (byUsername.isPresent()) {
+            return byUsername;
+        }
+        return userRepository.findByEmailIgnoreCase(login);
+    }
+
+    private String createResetTokenForUser(UserAccount user) {
+        passwordResetTokenRepository.deleteByUser(user);
+
+        String rawToken = generateToken();
+        String tokenHash = hashToken(rawToken);
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setUser(user);
+        token.setTokenHash(tokenHash);
+        token.setExpiresAt(Instant.now().plus(PASSWORD_RESET_DURATION));
+        passwordResetTokenRepository.save(token);
+
+        return rawToken;
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[32];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 MessageDigest not available", e);
+        }
+    }
+
+    public record LoginSuccess(String token, Duration ttl) {
+    }
+
+    public static class AuthException extends RuntimeException {
+        private final HttpStatus status;
+
+        public AuthException(HttpStatus status, String message) {
+            super(message);
+            this.status = status;
+        }
+
+        public HttpStatus getStatus() {
+            return status;
+        }
+    }
+}

--- a/TheOvalGuide-back/src/test/java/com/ross/theovalguide/controllers/AuthControllerIntegrationTest.java
+++ b/TheOvalGuide-back/src/test/java/com/ross/theovalguide/controllers/AuthControllerIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.ross.theovalguide.controllers;
+
+import com.ross.theovalguide.model.UserAccount;
+import com.ross.theovalguide.repo.PasswordResetTokenRepository;
+import com.ross.theovalguide.repo.SessionTokenRepository;
+import com.ross.theovalguide.repo.UserRepository;
+import com.ross.theovalguide.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthControllerIntegrationTest {
+
+    private static final String INITIAL_PASSWORD = "Password1!";
+    private static final String UPDATED_PASSWORD = "NewPassword2!";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SessionTokenRepository sessionTokenRepository;
+
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    void registerAndLoginWithUsernameAndEmail() throws Exception {
+        registerUser("student", "student@example.com", "student@osu.edu", INITIAL_PASSWORD);
+
+        assertThat(userRepository.findByUsernameIgnoreCase("student")).isPresent();
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginPayload("student", INITIAL_PASSWORD)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(cookie().exists(AuthController.AUTH_COOKIE_NAME));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginPayload("student@example.com", INITIAL_PASSWORD)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(cookie().exists(AuthController.AUTH_COOKIE_NAME));
+
+        UserAccount user = userRepository.findByUsernameIgnoreCase("student").orElseThrow();
+        assertThat(sessionTokenRepository.findAllByUser(user)).hasSize(1);
+    }
+
+    @Test
+    void registerWithDuplicateUsernameFails() throws Exception {
+        registerUser("student", "student@example.com", "student@osu.edu", INITIAL_PASSWORD);
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registrationPayload("student", "other@example.com", "other@osu.edu", INITIAL_PASSWORD)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Username already in use"));
+    }
+
+    @Test
+    void forgotPasswordGeneratesToken() throws Exception {
+        registerUser("student", "student@example.com", "student@osu.edu", INITIAL_PASSWORD);
+        UserAccount user = userRepository.findByUsernameIgnoreCase("student").orElseThrow();
+        assertThat(passwordResetTokenRepository.findAllByUser(user)).isEmpty();
+
+        mockMvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(forgotPasswordPayload("student@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+
+        assertThat(passwordResetTokenRepository.findAllByUser(user)).hasSize(1);
+    }
+
+    @Test
+    void updatePasswordChangesCredentialsAndInvalidatesSessions() throws Exception {
+        registerUser("student", "student@example.com", "student@osu.edu", INITIAL_PASSWORD);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginPayload("student", INITIAL_PASSWORD)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+
+        UserAccount user = userRepository.findByUsernameIgnoreCase("student").orElseThrow();
+        assertThat(sessionTokenRepository.findAllByUser(user)).hasSize(1);
+
+        Optional<String> token = authService.initiatePasswordReset("student@example.com");
+        assertThat(token).isPresent();
+
+        mockMvc.perform(post("/auth/update-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updatePasswordPayload(UPDATED_PASSWORD, token.orElseThrow())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+
+        user = userRepository.findByUsernameIgnoreCase("student").orElseThrow();
+        assertThat(sessionTokenRepository.findAllByUser(user)).isEmpty();
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginPayload("student", INITIAL_PASSWORD)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Invalid email/username or password"));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginPayload("student", UPDATED_PASSWORD)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+
+        user = userRepository.findByUsernameIgnoreCase("student").orElseThrow();
+        assertThat(sessionTokenRepository.findAllByUser(user)).hasSize(1);
+    }
+
+    private void registerUser(String username, String email, String schoolEmail, String password) throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registrationPayload(username, email, schoolEmail, password)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+
+    private String registrationPayload(String username, String email, String schoolEmail, String password) {
+        return """
+                {
+                  \"username\": \"%s\",
+                  \"email\": \"%s\",
+                  \"schoolEmail\": \"%s\",
+                  \"password\": \"%s\"
+                }
+                """.formatted(username, email, schoolEmail, password);
+    }
+
+    private String loginPayload(String login, String password) {
+        return """
+                {
+                  \"login\": \"%s\",
+                  \"password\": \"%s\"
+                }
+                """.formatted(login, password);
+    }
+
+    private String forgotPasswordPayload(String email) {
+        return """
+                {
+                  \"email\": \"%s\"
+                }
+                """.formatted(email);
+    }
+
+    private String updatePasswordPayload(String password, String token) {
+        return """
+                {
+                  \"password\": \"%s\",
+                  \"token\": \"%s\"
+                }
+                """.formatted(password, token);
+    }
+}

--- a/TheOvalGuide-back/src/test/resources/application-test.properties
+++ b/TheOvalGuide-back/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:theovalguide;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.sql.init.mode=never
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
## Summary
- add an AuthController with login, registration, forgot-password, and update-password endpoints that align with the frontend payloads and set the login cookie
- implement AuthService plus session/password-reset token entities and repositories to hash passwords, manage sessions, and handle reset links, along with required config updates
- expand backend dependencies, CORS settings, and test resources while covering the new behaviour with integration tests

## Testing
- mvn test *(fails: unable to reach Maven Central to resolve Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e177cfa08332937edd5459c1ba4c