### PR TITLE
Fix optional difficulty validation in review forms

### DIFF
--- a/theovalguide-front/app/professors/[slug]/components/ProfessorReviewForm.tsx
+++ b/theovalguide-front/app/professors/[slug]/components/ProfessorReviewForm.tsx
@@ -22,9 +22,28 @@ const SearchClassHit = z.object({
 });
 type SearchClassHit = z.infer<typeof SearchClassHit>;
 
+const optionalDifficultySchema = z.preprocess((value) => {
+  if (value === "" || value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return Number.isNaN(value) ? undefined : value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    const parsed = Number(trimmed);
+    return Number.isNaN(parsed) ? value : parsed;
+  }
+
+  return value;
+}, z.number().int().min(1).max(5).optional());
+
 const FormSchema = z.object({
   rating: z.coerce.number().int().min(1).max(5),
-  difficulty: z.coerce.number().int().min(1).max(5).optional(),
+  difficulty: optionalDifficultySchema,
   comment: z.string().max(500).optional(),
   tags: z.string().optional(),
 

--- a/theovalguide-front/components/forms/reviews.tsx
+++ b/theovalguide-front/components/forms/reviews.tsx
@@ -12,9 +12,28 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 // Zod schema
+const optionalDifficultySchema = z.preprocess((value) => {
+  if (value === "" || value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return Number.isNaN(value) ? undefined : value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    const parsed = Number(trimmed);
+    return Number.isNaN(parsed) ? value : parsed;
+  }
+
+  return value;
+}, z.number().int().min(1, "Min 1").max(5, "Max 5").optional());
+
 const schema = z.object({
   rating: z.coerce.number().int().min(1, "Min 1").max(5, "Max 5"),
-  difficulty: z.coerce.number().int().min(1, "Min 1").max(5, "Max 5").optional(),
+  difficulty: optionalDifficultySchema,
   comment: z.string().max(500, "Max 500 chars").optional(),
   tags: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- preprocess difficulty field values so blank entries become optional in the professor review form
- apply the same optional difficulty handling to the shared class review form

## Testing
- pnpm lint
- node - <<'NODE' # schema verification of difficulty handling


------
https://chatgpt.com/codex/tasks/task_e_68c9e178daac8332a5fbe082fa5a34cc